### PR TITLE
APPDEV-11258: Sierra URL updates add 773 and 599 fields

### DIFF
--- a/lib/ia_to_ht_ingest_prep/ia_bib.rb
+++ b/lib/ia_to_ht_ingest_prep/ia_bib.rb
@@ -38,6 +38,10 @@ module IaToHtIngestPrep
       @sierra.marc
     end
 
+    def marc_stub
+      @sierra.stub
+    end
+
     # Bib rec type in the context of IA
     def ia_rec_type
       case @sierra.bcode1

--- a/lib/ia_to_ht_ingest_prep/ia_bib_marc_stub.rb
+++ b/lib/ia_to_ht_ingest_prep/ia_bib_marc_stub.rb
@@ -2,52 +2,80 @@ module IaToHtIngestPrep
   # A standard MARC stub (e.g. 907, 944 batch load note, etc.) that also
   # includes needed 856s, and 530/949 fields as appropriate.
   class IaBibMarcStub
-    attr_reader :ia_bib
-
     def initialize(ia_bib)
       @ia_bib = ia_bib
+      @sierra_stub = ia_bib.marc_stub
+      @is_erec = ia_bib.erec?
+      @serial_or_mono = case
+                        when ia_bib.serial?
+                          then :serial
+                        when ia_bib.mono?
+                          then :mono
+                        end
+      @oca_items_exist = ia_bib.oca_items&.any?
     end
 
     def stub(m856s)
-      stub = ia_bib.sierra.stub
-      stub << proper_530 if lacking_oca_530?
+      stub = @sierra_stub
+      stub << proper_530 if lacking?(proper_530)
+
+      stub << proper_599 if lacking?(proper_599)
+      stub << proper_773 if lacking?(proper_773)
 
       m856s.each { |m856| stub << m856 }
-      stub << proper_949 unless ia_bib.oca_items&.any?
+      stub << proper_949 unless @oca_items_exist
 
       stub.sort
     end
 
-    # True when bib has no OCA 530 and needs one (i.e. not an e-record).
-    def lacking_oca_530?
-      return false unless proper_530
+    private
 
-      ia_bib.marc.fields.find { |f| f == proper_530 }.nil?
+    # True when bib lacks a given field
+    def lacking?(field)
+      return false unless field
+
+      @ia_bib.marc.fields.find { |f| f == field }.nil?
     end
 
     def proper_530
-      self.class.proper_530(ia_bib)
+      self.class.proper_530(is_erec: @is_erec)
+    end
+
+    def proper_599
+      self.class.proper_599
+    end
+
+    def proper_773
+      self.class.proper_773
     end
 
     def proper_949
-      self.class.proper_949(ia_bib)
+      self.class.proper_949(@serial_or_mono)
     end
 
     # returns the standard 530 for OCA bibs as a MARC::DataField
     # nil for e-records (which don't need a 530)
-    def self.proper_530(bib)
-      return if bib.erec?
+    def self.proper_530(is_erec:)
+      return if is_erec
 
       field_content = "Also available via the World Wide Web."
       MARC::DataField.new('530', ' ', ' ', ['a', field_content])
     end
 
+    def self.proper_599
+      MARC::DataField.new('599', ' ', ' ', ['a', 'LTIEXP'])
+    end
+
+    def self.proper_773
+      MARC::DataField.new('773', '0', ' ', ['t', 'Digitized by UNC Chapel Hill'])
+    end
+
     # returns a derived 949 for OCA item creation as a MARC::DataField
-    def self.proper_949(bib)
-      if bib.serial?
+    def self.proper_949(record_type)
+      if record_type == :serial
         item_loc = 'erri'
         stats_rec_type = 'journal'
-      elsif bib.mono?
+      elsif record_type == :mono
         item_loc = 'ebnb'
         stats_rec_type = 'book'
       end

--- a/lib/ia_to_ht_ingest_prep/version.rb
+++ b/lib/ia_to_ht_ingest_prep/version.rb
@@ -1,3 +1,3 @@
 module IaToHtIngestPrep
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/spec/ia_bib_marc_stub_spec.rb
+++ b/spec/ia_bib_marc_stub_spec.rb
@@ -3,30 +3,91 @@ require 'spec_helper'
 module IaToHtIngestPrep
   RSpec.describe IaBibMarcStub do
 
+    describe '#stub' do
+      let(:bib) do
+        bib = double(IaBib)
+        allow(bib).to receive(:marc_stub).and_return(MARC::Record.new)
+        allow(bib).to receive(:erec?)
+        allow(bib).to receive(:marc).and_return(MARC::Record.new)
+        allow(bib).to receive(:oca_items)
+        allow(bib).to receive(:serial?).and_return(true)
+
+        bib
+      end
+
+      context 'for serial records' do
+        it 'returns a serial MARC stub' do
+          # blackslashes (signifying empty indicators) need to be escaped
+          expected_mrk = <<~MRK
+            =LDR            22        4500
+            =530  \\\\$aAlso available via the World Wide Web.
+            =599  \\\\$aLTIEXP
+            =773  0\\$tDigitized by UNC Chapel Hill
+            =949  \\1$g1$lerri$h0$rn$t11$u-$jOCA electronic journal
+          MRK
+
+          expect(IaBibMarcStub.new(bib).stub([]).to_mrk).to eq(expected_mrk)
+        end
+      end
+
+      context 'for mono records' do
+        it 'returns a mono MARC stub' do
+          allow(bib).to receive(:serial?).and_return(false)
+          allow(bib).to receive(:mono?).and_return(true)
+
+          # blackslashes (signifying empty indicators) need to be escaped
+          expected_mrk = <<~MRK
+            =LDR            22        4500
+            =530  \\\\$aAlso available via the World Wide Web.
+            =599  \\\\$aLTIEXP
+            =773  0\\$tDigitized by UNC Chapel Hill
+            =949  \\1$g1$lebnb$h0$rn$t11$u-$jOCA electronic book
+          MRK
+
+          expect(IaBibMarcStub.new(bib).stub([]).to_mrk).to eq(expected_mrk)
+        end
+      end
+
+      it 'includes passed 856s in the stub' do
+        urls = [MARC::DataField.new('856', '4', '1', ['u', 'https://example.com'])]
+
+        expected_856 = '=856  41$uhttps://example.com'
+        expect(IaBibMarcStub.new(bib).stub(urls).to_mrk).to include(expected_856)
+      end
+    end
+
     describe '.proper_949' do
       book949 = '=949  \\1$g1$lebnb$h0$rn$t11$u-$jOCA electronic book'
       journal949 = '=949  \\1$g1$lerri$h0$rn$t11$u-$jOCA electronic journal'
 
-      sbmono = IaBibMarcStub.proper_949(IaBib.new(Sierra::Record.get('b1049731a')))
+      sbmono = IaBibMarcStub.proper_949(:mono)
       it 'returns book 949 for monographs' do
         expect(sbmono.to_mrk).to eq(book949)
       end
 
-      sbserial = IaBibMarcStub.proper_949(IaBib.new(Sierra::Record.get('b1636974a')))
+      sbserial = IaBibMarcStub.proper_949(:serial)
       it 'returns journal 949 for serials' do
         expect(sbserial.to_mrk).to eq(journal949)
       end
     end
 
     describe '.proper_530' do
-      sb1 = IaBibMarcStub.proper_530(IaBib.new(Sierra::Record.get('b1055966a')))
-      static_530 = '=530  \\\\$aAlso available via the World Wide Web.'
+      context 'for print records' do
+        sb1 = IaBibMarcStub.proper_530(is_erec: false)
 
-      it 'returns static 530 field' do
-        expect(sb1.to_mrk).to eq(static_530)
+        static_530 = '=530  \\\\$aAlso available via the World Wide Web.'
+        it 'returns static 530 field' do
+          expect(sb1.to_mrk).to eq(static_530)
+        end
       end
 
-      #todo when e-record returns nil
+      context 'for electronic records' do
+        sb1 = IaBibMarcStub.proper_530(is_erec: true)
+
+        it 'returns nil' do
+          expect(sb1).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- IA MARC stub includes a "Digitized by UNC Chapel Hill" 773 (for indexing/retrievability)
- IA MARC stub includes a 599 (for authority control processing)